### PR TITLE
feat: [sc-154159] update Rust SDK hello app readme and comments to standard design

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 We've built a simple console application that demonstrates how LaunchDarkly's SDK works.
 
-Below, you'll find the basic build procedure. For more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/) or the [Rust SDK reference guide](https://docs.launchdarkly.com/sdk/server-side/rust).
+Below, you'll find the build procedure. For more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/) or the [Rust SDK reference guide](https://docs.launchdarkly.com/sdk/server-side/rust).
 
 ## Build instructions
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
-# LaunchDarkly Sample Rust Application
+# LaunchDarkly sample Rust application
 
 We've built a simple console application that demonstrates how LaunchDarkly's SDK works.
 
-Below, you'll find the basic build procedure, but for more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/) or the [Rust SDK reference guide](https://docs.launchdarkly.com/sdk/server-side/rust).
+Below, you'll find the basic build procedure. For more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/) or the [Rust SDK reference guide](https://docs.launchdarkly.com/sdk/server-side/rust).
 
 ## Build instructions
 
-1. Set the environment variable `LAUNCHDARKLY_SDK_KEY` to your LaunchDarkly SDK key.
-2. Set the environment variable `FEATURE_FLAG_KEY` to the feature flag key in your LaunchDarkly project.
-3. On the command line, run `cargo run -q`.
+1. Edit main.rs and set the value of the environment variable `SDK_KEY` to your LaunchDarkly SDK key. If there is an existing boolean feature flag in your LaunchDarkly project that you want to evaluate, set the environment variable `FEATURE_FLAG_KEY` to the flag key.
 
-You should see the messsage `"Feature flag '<flag key>' is <true/false> for this user"`.
+```
+
+```
+
+2. On the command line, run `cargo run -q`.
+
+You should receive the message `"Feature flag '<flag key>' is <true/false> for this user"`.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,13 @@ Below, you'll find the basic build procedure. For more comprehensive instruction
 
 ## Build instructions
 
-1. Edit main.rs and set the value of the environment variable `SDK_KEY` to your LaunchDarkly SDK key. If there is an existing boolean feature flag in your LaunchDarkly project that you want to evaluate, set the environment variable `FEATURE_FLAG_KEY` to the flag key.
+1. On the command line, set the value of the environment variable `SDK_KEY` to your LaunchDarkly SDK key. 
+2. If there is an existing boolean feature flag in your LaunchDarkly project that you want to evaluate, set the environment variable `FEATURE_FLAG_KEY` to the flag key.
 
 ```
+export SDK_KEY="1234567890abcdef"
 
+export FEATURE_FLAG_KEY="my-boolean-flag"
 ```
 
 2. On the command line, run `cargo run -q`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,14 @@
+// Set SDK_KEY to your LaunchDarkly SDK key.
+// Set FEATURE_FLAG_KEY to the feature flag key you want to evaluate.
+
 use launchdarkly_server_sdk::{Client, ConfigBuilder, User};
 
 #[tokio::main]
 async fn main() {
     env_logger::init();
-
-    let sdk_key = std::env::var("LAUNCHDARKLY_SDK_KEY").expect("LAUNCHDARKLY_SDK_KEY env not set");
-    let feature_flag_key = std::env::var("FEATURE_FLAG_KEY").expect("FEATURE_FLAG_KEY env not set");
+    
+    let sdk_key = std::env::var("SDK_KEY").expect("Please edit main.rs to set SDK_KEY to your LaunchDarkly SDK key first");
+    let feature_flag_key = std::env::var("FEATURE_FLAG_KEY").expect("Please edit main.rs to set FEATURE_FLAG_KEY to your LaunchDarkly flag key first");
 
     let config = ConfigBuilder::new(&sdk_key).build();
     let client = Client::build(config).expect("Client failed to build");
@@ -15,7 +18,7 @@ async fn main() {
 
     // Wait to ensure the client has fully initialized.
     if !client.initialized_async().await {
-        panic!("Client failed to successfully initialize");
+        panic!("SDK failed to initialize");
     }
 
     // Set up the user properties. This user should appear on your LaunchDarkly users dashboard

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,11 @@
-// Set SDK_KEY to your LaunchDarkly SDK key.
-// Set FEATURE_FLAG_KEY to the feature flag key you want to evaluate.
-
 use launchdarkly_server_sdk::{Client, ConfigBuilder, User};
 
 #[tokio::main]
 async fn main() {
     env_logger::init();
     
-    let sdk_key = std::env::var("SDK_KEY").expect("Please edit main.rs to set SDK_KEY to your LaunchDarkly SDK key first");
-    let feature_flag_key = std::env::var("FEATURE_FLAG_KEY").expect("Please edit main.rs to set FEATURE_FLAG_KEY to your LaunchDarkly flag key first");
+    let sdk_key = std::env::var("SDK_KEY").expect("SDK_KEY env not set");
+    let feature_flag_key = std::env::var("FEATURE_FLAG_KEY").expect("FEATURE_FLAG_KEY env not set");
 
     let config = ConfigBuilder::new(&sdk_key).build();
     let client = Client::build(config).expect("Client failed to build");

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use launchdarkly_server_sdk::{Client, ConfigBuilder, User};
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    
+
     let sdk_key = std::env::var("SDK_KEY").expect("SDK_KEY env not set");
     let feature_flag_key = std::env::var("FEATURE_FLAG_KEY").expect("FEATURE_FLAG_KEY env not set");
 


### PR DESCRIPTION
After receiving some feedback that it'd be helpful if the Hello apps were more standardized, Docs team is working on updating them to [match the spec](https://launchdarkly.atlassian.net/wiki/spaces/ENG/pages/1499562073/SDK+hello+world).

Tested locally.

Story details: https://app.shortcut.com/launchdarkly/story/154159