### PR TITLE
Rust rustfmt on main.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,8 @@ async fn main() {
     env_logger::init();
 
     let sdk_key = std::env::var("SDK_KEY").expect("SDK_KEY env should be set");
-    let feature_flag_key = std::env::var("FEATURE_FLAG_KEY").expect("FEATURE_FLAG_KEY env should be set");
+    let feature_flag_key =
+        std::env::var("FEATURE_FLAG_KEY").expect("FEATURE_FLAG_KEY env should be set");
 
     let config = ConfigBuilder::new(&sdk_key).build();
     let client = Client::build(config).expect("Client failed to build");


### PR DESCRIPTION
CI was failing because the main.rs file isn't formatted.