### PR TITLE
fix: Bump Rust version to 1.92.0 to support 2024 edition dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup rust tooling
-        run: rustup override set 1.74.1
+        run: rustup override set 1.92.0
 
       - uses: launchdarkly/gh-actions/actions/verify-hello-app@verify-hello-app-v2.0.1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hello-rust"
 version = "0.1.0"
-rust-version = "1.74.1"
+rust-version = "1.92.0"
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
## Summary

Bumps the pinned Rust toolchain from 1.74.1 to 1.92.0 in both `Cargo.toml` and the CI workflow. The daily scheduled CI has been failing since late May 2025 because transitive dependencies (notably `getrandom@0.4.2`) now use the Rust 2024 edition, which requires ≥1.85.0, and the LaunchDarkly SDK packages (`launchdarkly-server-sdk@3.0.1`, `launchdarkly-sdk-transport@0.1.1`, etc.) require ≥1.92.0.

## Review & Testing Checklist for Human

- [ ] Verify CI passes end-to-end (the build was validated locally with `cargo check`, but the full CI also runs the app against a live LaunchDarkly environment via `cargo run -q`)

### Notes

- Requested by: @kinyoklion
- [Devin session](https://app.devin.ai/sessions/d1b82c4353a348e69e803111d619ed4f)