### PR TITLE
chore: upgrade rust toolchain to 1.93.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup rust tooling
-        run: rustup override set 1.92.0
+        run: rustup override set 1.93.0
 
       - uses: launchdarkly/gh-actions/actions/verify-hello-app@verify-hello-app-v2.0.1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "hello-rust"
 version = "0.1.0"
-rust-version = "1.92.0"
-edition = "2018"
+rust-version = "1.93.0"
+edition = "2021"
 
 [dependencies]
-env_logger = "0.10.0"
+env_logger = "0.11.10"
 launchdarkly-server-sdk = ">=3.0.0"
-tokio = { version = "1.15.0", features = ["rt", "macros"] }
+tokio = { version = "1.44.2", features = ["rt", "macros"] }
 
 [features]


### PR DESCRIPTION
## Summary
The LaunchDarkly SDK dependencies (`launchdarkly-server-sdk@3.0.2`, `eventsource-client@0.17.3`, `launchdarkly-sdk-transport@0.1.2`, `launchdarkly-server-sdk-evaluation@2.1.3`) now require rustc 1.93.0, but the CI was pinned to 1.92.0 causing daily build failures.

Changes:
- Update `rust-version` from 1.92.0 to 1.93.0
- Update CI workflow to use `rustup override set 1.93.0`
- Bump edition from 2018 to 2021
- Update `env_logger` minimum from 0.10.0 to 0.11.10
- Update `tokio` minimum from 1.15.0 to 1.44.2

## Review & Testing Checklist for Human
- [ ] Verify the daily scheduled CI build passes with the new toolchain version
- [ ] Confirm `cargo run` still works locally with rustc 1.93.0

### Notes
Verified locally that `cargo check` passes with rustc 1.93.0 and all updated dependencies.

Link to Devin session: https://app.devin.ai/sessions/48341fafe64d470ba329351c960f1706
Requested by: @kinyoklion