### PR TITLE
chore: update minimum Rust version from 1.93.0 to 1.94.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup rust tooling
-        run: rustup override set 1.93.0
+        run: rustup override set 1.94.0
 
       - uses: launchdarkly/gh-actions/actions/verify-hello-app@verify-hello-app-v2.0.1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hello-rust"
 version = "0.1.0"
-rust-version = "1.93.0"
+rust-version = "1.94.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary

The LaunchDarkly Rust SDK dependencies (`launchdarkly-server-sdk@3.1.1`, `launchdarkly-server-sdk-evaluation@2.1.4`, `eventsource-client@0.17.5`, `launchdarkly-sdk-transport@0.1.3`) now require Rust 1.94.0. This updates `rust-version` in `Cargo.toml` and the `rustup override set` in CI to match.

Link to Devin session: https://app.devin.ai/sessions/5dd2e92259b8419089c07f65facee963
Requested by: @kinyoklion